### PR TITLE
Make password an optional parameter - Fixes #8

### DIFF
--- a/resource_clc_server.go
+++ b/resource_clc_server.go
@@ -44,11 +44,11 @@ func resourceCLCServer() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			// optional
 			"password": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
-			// optional
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
Make `password` an optional parameter. Fixes #8 

If not specified, a root password will be auto-generated upon VM creation, which saves having to store root passwords in config files. 
